### PR TITLE
feat(agent): use pre-job hook to install toolbox

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.0.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v2.2.3"
+appVersion: "v2.2.4"

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -5,6 +5,9 @@ Install one or multiple [Semaphore agent](https://github.com/semaphoreci/agent) 
 - [Autoscaling](#autoscaling)
   - [Disable autoscaling](#disable-autoscaling)
   - [Configure autoscaling policies](#configure-autoscaling-policies)
+- [Using a pre-job hook](#using-a-pre-job-hook)
+  - [Disabling the pre-job hook](#disabling-the-pre-job-hook)
+  - [Using a custom pre-job hook](#using-a-custom-pre-job-hook)
 
 ## Installation
 
@@ -103,4 +106,34 @@ helm upgrade --install semaphore-agent charts/agent \
   --namespace semaphore \
   --create-namespace \
   -f values.yml
+```
+
+## Using a pre-job hook
+
+By default, a pre-job hook is used to install the Semaphore toolbox. However, we recommend pre-installing the Semaphore toolbox (and any other required tools for your builds) in the images used during the jobs, to avoid wasting job running time to install dependencies.
+
+### Disabling the pre-job hook
+
+If you do not want to use the default pre-job hook, you can disable it with the `jobs.preJobHook.enabled` value:
+
+```
+helm upgrade --install brand-new-type charts/agent \
+  --namespace semaphore \
+  --create-namespace \
+  --set agent.endpoint=<your-organization>.semaphoreci.com \
+  --set agent.token=<your-agent-type-registration-token> \
+  --set jobs.preJobHook.enabled=false
+```
+
+### Using a custom pre-job hook
+
+If the default pre-job hook does not fit your needs, you can use a custom one with the `jobs.preJobHook.customScript` value:
+
+```
+helm upgrade --install brand-new-type charts/agent \
+  --namespace semaphore \
+  --create-namespace \
+  --set agent.endpoint=<your-organization>.semaphoreci.com \
+  --set agent.token=<your-agent-type-registration-token> \
+  --set jobs.preJobHook.customScript=$(cat my-custom-script.sh | base64)
 ```

--- a/charts/agent/pre-job-hook.sh
+++ b/charts/agent/pre-job-hook.sh
@@ -1,0 +1,20 @@
+set -eo pipefail
+
+# Install the Semaphore toolbox in the job
+rm -rf ~/.toolbox
+downloadPath="https://github.com/semaphoreci/toolbox/releases/download/v1.19.40/self-hosted-linux.tar"
+echo "Installing Semaphore toolbox from $downloadPath..."
+curl -sL --retry 5 --connect-timeout 3 $downloadPath -o /tmp/toolbox.tar
+tar -xvf /tmp/toolbox.tar
+mv toolbox ~/.toolbox
+bash ~/.toolbox/install-toolbox
+source ~/.toolbox/toolbox
+echo "Semaphore toolbox successfully installed."
+
+# Create SSH configuration.
+# This is required in order to avoid having to manually accept the GitHub SSH keys fingerprints on checkout.
+# Ideally, we should populate ~/.ssh/known_hosts with the GitHub keys from api.github.com/meta.
+mkdir -p ~/.ssh
+echo 'Host github.com' | tee -a ~/.ssh/config
+echo '  StrictHostKeyChecking no' | tee -a ~/.ssh/config
+echo '  UserKnownHostsFile=/dev/null' | tee -a ~/.ssh/config

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -66,3 +66,39 @@ Expand the name of the pod spec config map.
 {{- define "agent.podSpecName" -}}
 {{ include "agent.fullname" . }}-pod-spec
 {{- end }}
+
+{{/*
+Define the main container configuration.
+If preJobHook is used, we need to modify it to include the hook mount.
+*/}}
+{{- define "agent.job.podSpec.mainContainer" -}}
+{{- if .Values.jobs.preJobHook.enabled }}
+{{- $mainContainerSpec := deepCopy .Values.jobs.podSpec.mainContainer }}
+{{- $preJobHookMount := dict "name" "agent-config-volume" "mountPath" .Values.jobs.preJobHook.path "readOnly" true "subPath" "pre-job-hook" }}
+{{- $currentVolumeMounts := $mainContainerSpec.volumeMounts | default list }}
+{{- $newVolumeMounts := append $currentVolumeMounts $preJobHookMount }}
+{{- $_ := set $mainContainerSpec "volumeMounts" $newVolumeMounts }}
+{{- toYaml $mainContainerSpec }}
+{{- else }}
+{{- toYaml .Values.jobs.podSpec.mainContainer }}
+{{- end }}
+{{- end }}
+
+{{/*
+Define the pod configuration.
+If preJobHook is used, we need to modify it to include the hook mount.
+*/}}
+{{- define "agent.job.podSpec.pod" -}}
+{{- if .Values.jobs.preJobHook.enabled }}
+{{- $podSpec := deepCopy .Values.jobs.podSpec.pod }}
+{{- $secretItem := dict "key" "pre-job-hook" "path" "pre-job-hook" }}
+{{- $secretDict := dict "secretName" (include "agent.fullname" .) "defaultMode" 0644 "items" (list $secretItem) }}
+{{- $preJobHookVolume := dict "name" "agent-config-volume" "secret" $secretDict }}
+{{- $currentVolumes := $podSpec.volumes | default list }}
+{{- $newVolumes := append $currentVolumes $preJobHookVolume }}
+{{- $_ := set $podSpec "volumes" $newVolumes }}
+{{- toYaml $podSpec }}
+{{- else }}
+{{- toYaml .Values.jobs.podSpec.pod }}
+{{- end }}
+{{- end }}

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -74,7 +74,7 @@ If preJobHook is used, we need to modify it to include the hook mount.
 {{- define "agent.job.podSpec.mainContainer" -}}
 {{- if .Values.jobs.preJobHook.enabled }}
 {{- $mainContainerSpec := deepCopy .Values.jobs.podSpec.mainContainer }}
-{{- $preJobHookMount := dict "name" "agent-config-volume" "mountPath" .Values.jobs.preJobHook.path "readOnly" true "subPath" "pre-job-hook" }}
+{{- $preJobHookMount := dict "name" "agent-config-volume" "mountPath" .Values.jobs.preJobHook.path "readOnly" true }}
 {{- $currentVolumeMounts := $mainContainerSpec.volumeMounts | default list }}
 {{- $newVolumeMounts := append $currentVolumeMounts $preJobHookMount }}
 {{- $_ := set $mainContainerSpec "volumeMounts" $newVolumeMounts }}

--- a/charts/agent/templates/config-map.yaml
+++ b/charts/agent/templates/config-map.yaml
@@ -6,16 +6,10 @@ metadata:
   labels:
     {{- include "agent.labels" . | nindent 4 }}
 data:
-  {{- if .Values.jobs.podSpec.mainContainer }}
   mainContainer: |
-{{ toYaml .Values.jobs.podSpec.mainContainer | indent 4 }}
-  {{- end }}
-  {{- if .Values.jobs.podSpec.sidecarContainers }}
+{{ include "agent.job.podSpec.mainContainer" . | indent 4 }}
   sidecarContainers: |
 {{ toYaml .Values.jobs.podSpec.sidecarContainers | indent 4 }}
-  {{- end }}
-  {{- if .Values.jobs.podSpec.pod }}
   pod: |
-{{ toYaml .Values.jobs.podSpec.pod | indent 4 }}
-  {{- end }}
+{{ include "agent.job.podSpec.pod" . | indent 4 }}
 {{- end }}

--- a/charts/agent/templates/secret.yaml
+++ b/charts/agent/templates/secret.yaml
@@ -26,6 +26,7 @@ stringData:
     {{- if .Values.jobs.preJobHook.enabled }}
     pre-job-hook-path: {{ .Values.jobs.preJobHook.path }}/pre-job-hook
     fail-on-pre-job-hook-error: {{ .Values.jobs.preJobHook.failOnError }}
+    source-pre-job-hook: true
     {{- end }}
 
   {{- if .Values.jobs.preJobHook.enabled }}

--- a/charts/agent/templates/secret.yaml
+++ b/charts/agent/templates/secret.yaml
@@ -29,7 +29,10 @@ stringData:
     source-pre-job-hook: true
     {{- end }}
 
-  {{- if .Values.jobs.preJobHook.enabled }}
+  {{- if and .Values.jobs.preJobHook.enabled .Values.jobs.preJobHook.customScript }}
   pre-job-hook: |
-{{ tpl .Values.jobs.preJobHook.script . | indent 4 }}
+{{ .Values.jobs.preJobHook.customScript | b64dec | indent 4 }}
+  {{- else }}
+  pre-job-hook: |
+{{ .Files.Get "pre-job-hook.sh" | indent 4 }}
   {{- end }}

--- a/charts/agent/templates/secret.yaml
+++ b/charts/agent/templates/secret.yaml
@@ -24,7 +24,8 @@ stringData:
     kubernetes-pod-spec: {{ include "agent.podSpecName" . }}
     {{- end }}
     {{- if .Values.jobs.preJobHook.enabled }}
-    pre-job-hook-path: {{ .Values.jobs.preJobHook.path }}
+    pre-job-hook-path: {{ .Values.jobs.preJobHook.path }}/pre-job-hook
+    fail-on-pre-job-hook-error: {{ .Values.jobs.preJobHook.failOnError }}
     {{- end }}
 
   {{- if .Values.jobs.preJobHook.enabled }}

--- a/charts/agent/templates/secret.yaml
+++ b/charts/agent/templates/secret.yaml
@@ -23,3 +23,11 @@ stringData:
     {{- if .Values.jobs.podSpec }}
     kubernetes-pod-spec: {{ include "agent.podSpecName" . }}
     {{- end }}
+    {{- if .Values.jobs.preJobHook.enabled }}
+    pre-job-hook-path: {{ .Values.jobs.preJobHook.path }}
+    {{- end }}
+
+  {{- if .Values.jobs.preJobHook.enabled }}
+  pre-job-hook: |
+{{ tpl .Values.jobs.preJobHook.script . | indent 4 }}
+  {{- end }}

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -110,6 +110,5 @@ jobs:
   preJobHook:
     enabled: true
     path: "/opt/semaphore/hooks"
-    toolboxVersion: "v1.19.40"
     failOnError: true
     customScript: ""

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -109,8 +109,9 @@ jobs:
   # If enabled, we store the script in a secret, and inject it into the pod running job for execution.
   preJobHook:
     enabled: true
-    path: "/opt/semaphore/hooks/pre-job"
+    path: "/opt/semaphore/hooks"
     toolboxVersion: "v1.19.40"
+    failOnError: true
     script: |
       rm -rf ~/.toolbox
       downloadPath="https://github.com/semaphoreci/toolbox/releases/download/{{ .Values.jobs.preJobHook.toolboxVersion }}/self-hosted-linux.tar"

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -113,6 +113,9 @@ jobs:
     toolboxVersion: "v1.19.40"
     failOnError: true
     script: |
+      set -eo pipefail
+
+      # Install the Semaphore toolbox in the job
       rm -rf ~/.toolbox
       downloadPath="https://github.com/semaphoreci/toolbox/releases/download/{{ .Values.jobs.preJobHook.toolboxVersion }}/self-hosted-linux.tar"
       echo "Installing Semaphore toolbox from $downloadPath..."
@@ -122,3 +125,9 @@ jobs:
       bash ~/.toolbox/install-toolbox
       source ~/.toolbox/toolbox
       echo "Semaphore toolbox successfully installed."
+
+      # Configure SSH
+      mkdir -p ~/.ssh
+      echo 'Host github.com' | tee -a ~/.ssh/config
+      echo '  StrictHostKeyChecking no' | tee -a ~/.ssh/config
+      echo '  UserKnownHostsFile=/dev/null' | tee -a ~/.ssh/config

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -126,7 +126,9 @@ jobs:
       source ~/.toolbox/toolbox
       echo "Semaphore toolbox successfully installed."
 
-      # Configure SSH
+      # Create SSH configuration.
+      # This is required in order to avoid having to manually accept the GitHub SSH keys fingerprints on checkout.
+      # Ideally, we should populate ~/.ssh/known_hosts with the GitHub keys from api.github.com/meta.
       mkdir -p ~/.ssh
       echo 'Host github.com' | tee -a ~/.ssh/config
       echo '  StrictHostKeyChecking no' | tee -a ~/.ssh/config

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -112,24 +112,4 @@ jobs:
     path: "/opt/semaphore/hooks"
     toolboxVersion: "v1.19.40"
     failOnError: true
-    script: |
-      set -eo pipefail
-
-      # Install the Semaphore toolbox in the job
-      rm -rf ~/.toolbox
-      downloadPath="https://github.com/semaphoreci/toolbox/releases/download/{{ .Values.jobs.preJobHook.toolboxVersion }}/self-hosted-linux.tar"
-      echo "Installing Semaphore toolbox from $downloadPath..."
-      curl -sL --retry 5 --connect-timeout 3 $downloadPath -o /tmp/toolbox.tar
-      tar -xvf /tmp/toolbox.tar
-      mv toolbox ~/.toolbox
-      bash ~/.toolbox/install-toolbox
-      source ~/.toolbox/toolbox
-      echo "Semaphore toolbox successfully installed."
-
-      # Create SSH configuration.
-      # This is required in order to avoid having to manually accept the GitHub SSH keys fingerprints on checkout.
-      # Ideally, we should populate ~/.ssh/known_hosts with the GitHub keys from api.github.com/meta.
-      mkdir -p ~/.ssh
-      echo 'Host github.com' | tee -a ~/.ssh/config
-      echo '  StrictHostKeyChecking no' | tee -a ~/.ssh/config
-      echo '  UserKnownHostsFile=/dev/null' | tee -a ~/.ssh/config
+    customScript: ""

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -99,9 +99,25 @@ jobs:
   # Additional configuration for the main container, sidecar containers and the pod itself.
   # See: https://github.com/semaphoreci/agent/blob/master/docs/kubernetes-executor.md#--kubernetes-pod-spec
   podSpec:
-    mainContainer:
-      imagePullPolicy: IfNotPresent
-    sidecarContainers:
-      imagePullPolicy: IfNotPresent
-    pod:
-      imagePullSecrets: []
+    mainContainer: {}
+    sidecarContainers: {}
+    pod: {}
+
+  # The pre-job hook configuration.
+  # See: https://docs.semaphoreci.com/ci-cd-environment/configure-self-hosted-agent/#pre-job-hook-path.
+  # By default, this is enabled, and we use that hook to install the Semaphore toolbox.
+  # If enabled, we store the script in a secret, and inject it into the pod running job for execution.
+  preJobHook:
+    enabled: true
+    path: "/opt/semaphore/hooks/pre-job"
+    toolboxVersion: "v1.19.40"
+    script: |
+      rm -rf ~/.toolbox
+      downloadPath="https://github.com/semaphoreci/toolbox/releases/download/{{ .Values.jobs.preJobHook.toolboxVersion }}/self-hosted-linux.tar"
+      echo "Installing Semaphore toolbox from $downloadPath..."
+      curl -sL --retry 5 --connect-timeout 3 $downloadPath -o /tmp/toolbox.tar
+      tar -xvf /tmp/toolbox.tar
+      mv toolbox ~/.toolbox
+      bash ~/.toolbox/install-toolbox
+      source ~/.toolbox/toolbox
+      echo "Semaphore toolbox successfully installed."


### PR DESCRIPTION
Currently, the image used by the Semaphore job must have the Semaphore toolbox installed in it. Installing the Semaphore toolbox in the Docker images used in jobs is better since it saves some job execution time. However, it's not the friendliest experience for newcomers since it requires them to build and publish images somewhere before they can start using this chart.

To address that, this pull request configures the agent to execute a pre-job hook that installs the toolbox for the job.

### Other changes

The pre-job hook also creates a `~/.ssh/config`, so we are not prompted to manually accept the GitHub SSH key fingerprints when using `checkout`. Later on, we should use the GitHub meta API and inject their SSH keys into `~/.ssh/known_hosts`, as [renderedtext/agent-aws-stack](https://github.com/renderedtext/agent-aws-stack) does.