### PR TITLE
fix(agent): properly configure initial agent pool size

### DIFF
--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -3,6 +3,7 @@ Install one or multiple [Semaphore agent](https://github.com/semaphoreci/agent) 
 - [Installation](#installation)
   - [Using multiple agent type pools](#using-multiple-agent-type-pools)
 - [Autoscaling](#autoscaling)
+  - [Configure agent pool size](#configure-agent-pool-size)
   - [Disable autoscaling](#disable-autoscaling)
   - [Configure autoscaling policies](#configure-autoscaling-policies)
 - [Using a pre-job hook](#using-a-pre-job-hook)
@@ -49,9 +50,9 @@ helm upgrade --install my-second-agent-type-pool charts/agent \
 
 By default, the Semaphore agent deployment will scale up and down, based on the metrics exposed by the Semaphore API. It relies on the [custom Semaphore metrics server](https://github.com/renderedtext/k8s-metrics-apiserver) to be installed in the same namespace. You can use the [external-metrics-server](../external-metrics-server) chart to install it on your Kubernetes cluster.
 
-### Disable autoscaling
+### Configure agent pool size
 
-If you don't want the agent deployment to automatically scale, you can disable it:
+By default, the agent pool will have a minimum of 1 agent and a maximum of 10 agents. However, you can configure it with the `agent.autoscaling.min` and `agent.autoscaling.max` values. For example, to create an agent pool that has between 5 and 25 agents:
 
 ```
 helm install semaphore-agent charts/agent \
@@ -59,7 +60,22 @@ helm install semaphore-agent charts/agent \
   --create-namespace \
   --set agent.endpoint=<your-organization>.semaphoreci.com \
   --set agent.token=<your-agent-type-registration-token> \
-  --set autoscaling.enabled=false
+  --set agent.autoscaling.min=5 \
+  --set agent.autoscaling.max=25
+```
+
+### Disable autoscaling
+
+If you don't want the agent deployment to automatically scale, you can disable it with the `agent.autoscaling.enabled` value. Also, if autoscaling is not enabled, the number of agents is configured with the `agent.replicas` value. For example, you can install a static agent pool of 25 agents with the following:
+
+```
+helm install semaphore-agent charts/agent \
+  --namespace semaphore \
+  --create-namespace \
+  --set agent.endpoint=<your-organization>.semaphoreci.com \
+  --set agent.token=<your-agent-type-registration-token> \
+  --set agent.autoscaling.enabled=false \
+  --set agent.replicas=25
 ```
 
 ### Configure autoscaling policies

--- a/charts/agent/templates/deployment.yaml
+++ b/charts/agent/templates/deployment.yaml
@@ -5,7 +5,11 @@ metadata:
   labels:
     {{- include "agent.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  {{- if .Values.agent.autoscaling.enabled }}
+  replicas: {{ .Values.agent.autoscaling.min }}
+  {{- else }}
+  replicas: {{ .Values.agent.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "agent.selectorLabels" . | nindent 6 }}

--- a/charts/agent/templates/hpa.yaml
+++ b/charts/agent/templates/hpa.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.agent.autoscaling.enabled }}
+{{- if .Capabilities.APIVersions.Has "autoscaling/v2" }}
 apiVersion: autoscaling/v2
+{{- else }}
+apiVersion: autoscaling/v2beta2
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "agent.fullname" . }}-down
@@ -28,7 +32,11 @@ spec:
     scaleUp:
       selectPolicy: Disabled
 ---
+{{- if .Capabilities.APIVersions.Has "autoscaling/v2" }}
 apiVersion: autoscaling/v2
+{{- else }}
+apiVersion: autoscaling/v2beta2
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "agent.fullname" . }}-up

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -55,6 +55,11 @@ agent:
       cpu: 0.05
       memory: 25Mi
 
+  # The number of replicas for the agent deployment.
+  # This is used if agent.autoscaling.enabled is not true.
+  # If agent.autoscaling.enabled is true, agent.autoscaling.min is used instead.
+  replicas: 1
+
   # NOTE: this requires the external-metrics-server chart to be installed.
   autoscaling:
     enabled: true


### PR DESCRIPTION
Adds a `.Values.agent.replicas` value to allow configuring a statically-sized pool of agents. If `agent.autoscaling.enabled` is false, we use it. Otherwise, we use `agent.autoscaling.min` as the initial replica count.

### Other fixes

- The `autoscaling/v2` API was introduced in Kubernetes 1.23. For older versions of Kubernetes, we need to use ` autoscaling/v2beta2`