### PR TITLE
fix(agent): set terminationGracePeriodSeconds on deployment

### DIFF
--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -102,3 +102,12 @@ If preJobHook is used, we need to modify it to include the hook mount.
 {{- toYaml .Values.jobs.podSpec.pod }}
 {{- end }}
 {{- end }}
+
+{{/*
+Define the agent deployment's grace period.
+We use interruptionGracePeriod + 5 minutes here to make sure the agent
+has enough time to stop and finish the job if the job doesn't finish in time.
+*/}}
+{{- define "agent.gracePeriod" -}}
+{{- add .Values.agent.interruptionGracePeriod 120 }}
+{{- end }}

--- a/charts/agent/templates/deployment.yaml
+++ b/charts/agent/templates/deployment.yaml
@@ -23,6 +23,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "agent.fullname" . }}
+      terminationGracePeriodSeconds: {{ include "agent.gracePeriod" . }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.agent.image }}:{{ .Values.agent.imageTag | default .Chart.AppVersion }}"


### PR DESCRIPTION
The `.Values.agent.interruptionGracePeriod` should also be used to set the `terminationGracePeriodSeconds` in the agent deployment. If not used, the agent might continue waiting for the job to finish while the default k8s grace period is reached, and Kubernetes kills the pod.