### PR TITLE
fix(agent): do not set replicas if autoscaling is enabled

### DIFF
--- a/charts/agent/templates/deployment.yaml
+++ b/charts/agent/templates/deployment.yaml
@@ -5,9 +5,7 @@ metadata:
   labels:
     {{- include "agent.labels" . | nindent 4 }}
 spec:
-  {{- if .Values.agent.autoscaling.enabled }}
-  replicas: {{ .Values.agent.autoscaling.min }}
-  {{- else }}
+  {{- if not .Values.agent.autoscaling.enabled }}
   replicas: {{ .Values.agent.replicas }}
   {{- end }}
   selector:


### PR DESCRIPTION
If autoscaling is being used, we should let the HPA handle the number of replicas, and not set them directly in the deployment.