### PR TITLE
feat: add new chart for agent-k8s-controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Semaphore Helm charts
 
 Helm repository for Semaphore charts. The current charts available are:
-- [Semaphore agent](./charts/agent/)
-- [External metrics server](./charts/external-metrics-server/)
+- [Semaphore controller](./charts/controller/)
+- (*deprecated*) [Semaphore agent](./charts/agent/)
+- (*deprecated*) [External metrics server](./charts/external-metrics-server/)
 
 ## Usage
 

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,3 +1,6 @@
+> [!WARNING]
+> This chart is deprecated. It does not work well with versions of Kubernetes >= 1.26. Please, use the [Semaphore custom controller chart](../controller) to run Semaphore jobs in your Kubernetes cluster.
+
 Install one or multiple [Semaphore agent](https://github.com/semaphoreci/agent) pools in a Kubernetes cluster.
 
 - [Installation](#installation)

--- a/charts/controller/.helmignore
+++ b/charts/controller/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/controller/Chart.yaml
+++ b/charts/controller/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: controller
+description: A Helm chart to install the Semaphore job controller
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "v0.1.0"

--- a/charts/controller/README.md
+++ b/charts/controller/README.md
@@ -1,0 +1,202 @@
+Run Semaphore jobs for one or multiple [Semaphore agent type](https://github.com/semaphoreci/agent) pools in a Kubernetes cluster.
+
+- [Installation](#installation)
+- [Start jobs for an agent type](#start-jobs-for-an-agent-type)
+- [Using multiple agent types](#using-multiple-agent-types)
+- [Default pod spec](#default-pod-spec)
+  - [The pre-job hook](#the-pre-job-hook)
+  - [Disabling the pre-job hook](#disabling-the-pre-job-hook)
+  - [Using a custom pre-job hook](#using-a-custom-pre-job-hook)
+  - [Do not specify a default pod spec](#do-not-specify-a-default-pod-spec)
+  - [Overriding the default pod spec values](#overriding-the-default-pod-spec-values)
+  - [Overriding the default pod spec for a single agent type](#overriding-the-default-pod-spec-for-a-single-agent-type)
+- [Logging](#logging)
+- [Configuration](#configuration)
+
+## Installation
+
+Using the Semaphore API token, install the chart:
+
+```bash
+helm upgrade --install semaphore-controller charts/controller \
+  --namespace semaphore \
+  --create-namespace \
+  --set endpoint=<your-organization>.semaphoreci.com \
+  --set apiToken=<your-api-token>
+```
+
+## Start jobs for an agent type
+
+The controller automatically detects which agent types to monitor by looking at the secrets available in the namespace it is running on. To start monitoring the queue and creating jobs for an agent type, you need to create a Kubernetes secret with the necessary information for the controller to spin new agents for that agent type.
+
+You can follow the guide [here](https://docs.semaphoreci.com/ci-cd-environment/self-hosted-agent-types/) to create an agent type. After doing so, you can start creating jobs for it by creating a secret like this:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-semaphore-agent-type
+  namespace: semaphore
+  labels:
+    semaphoreci.com/resource-type: agent-type-configuration
+stringData:
+  agentTypeName: s1-my-agent-type
+  registrationToken: <agent-type-registration-token>
+```
+
+Notice the `semaphoreci.com/resource-type=agent-type-configuration` label. That's how the controller knows this secret has the information needed to start agents for a Semaphore agent type.
+
+## Using multiple agent types
+
+You can start jobs for as many agent types you want. Just be aware that the controller will respect the `parallelism` settings and will not create more than the amount of jobs specified in that settings, for all the agent types you have.
+
+## Default pod spec
+
+The controller is responsible for starting Semaphore agents to run the jobs that appear in the queue for your agent type. Each Semaphore agent that starts will itself create a new pod to run the job that it is assigned. The agent configures that pod configured using a [pod spec](https://github.com/semaphoreci/agent/blob/master/docs/kubernetes-executor.md#--kubernetes-pod-spec) decorator.
+
+This chart provides a default pod spec that the controller will use for all agent types that do not specify it themselves.
+
+### The pre-job hook
+
+By default, the controller's default pod spec includes a pre-job hook used to install the Semaphore toolbox at the beginning of every job.
+
+> [!TIP]
+> Pre-installing the Semaphore toolbox (and any other required tools for your builds) in the images used during the jobs is a good way to avoid wasting job running time to install dependencies.
+
+### Disabling the pre-job hook
+
+If you do not want to use the default pre-job hook, you can disable it with the `agent.defaultPodSpec.preJobHook.enabled` value:
+
+```bash
+helm upgrade --install semaphore-controller charts/controller \
+  --namespace semaphore \
+  --create-namespace \
+  --set endpoint=<your-organization>.semaphoreci.com \
+  --set apiToken=<your-api-token> \
+  --set agent.defaultPodSpec.preJobHook.enabled=false
+```
+
+### Using a custom pre-job hook
+
+If the default pre-job hook does not fit your needs, you can use a custom one with the `agent.defaultPodSpec.preJobHook.customScript` value:
+
+```bash
+helm upgrade --install semaphore-controller charts/controller \
+  --namespace semaphore \
+  --create-namespace \
+  --set endpoint=<your-organization>.semaphoreci.com \
+  --set apiToken=<your-api-token> \
+  --set agent.defaultPodSpec.preJobHook.customScript=$(cat my-custom-script.sh | base64)
+```
+
+### Do not specify a default pod spec
+
+If you do not want to have a default pod spec for your agent types, you can disable it with:
+
+```bash
+helm upgrade --install semaphore-controller charts/controller \
+  --namespace semaphore \
+  --create-namespace \
+  --set endpoint=<your-organization>.semaphoreci.com \
+  --set apiToken=<your-api-token> \
+  --set agent.defaultPodSpec.enabled=false
+```
+
+### Overriding the default pod spec values
+
+You can also configure the pod, main container and sidecar containers for the default controller's pod spec, specifying the `agent.defaultPodSpec.pod`, `agent.defaultPodSpec.mainContainer` and `agent.defaultPodSpec.sidecarContainers` parameters.
+
+For example, if you have a `custom-values.yml` file like this:
+
+```yaml
+endpoint: <your-organization>.semaphoreci.com
+apiToken: <your-api-token>
+agent:
+  defaultPodSpec:
+    mainContainer:
+      env:
+        - name: FOO_1
+          value: BAR_1
+        - name: FOO_2
+          value: BAR_2
+```
+
+You can expose `FOO_1` and `FOO_2` environment variables to all Semaphore jobs. To install it:
+
+```bash
+helm upgrade --install semaphore-controller charts/controller \
+  --namespace semaphore \
+  --create-namespace \
+  -f custom-values.yml
+```
+
+### Overriding the default pod spec for a single agent type
+
+You might need to configure the pods to run the Semaphore jobs differently depending on the agent type. You can do that by specifying a `agentStartupParameters` field in your agent type secret.
+
+For example, if you want to use a different pod spec only for an agent type `s1-my-agent-type-2`, you can do so by specifying the `agentStartupParameters` in the agent type secret:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: custom-pre-job-hook-for-my-agent-type-1
+  namespace: semaphore
+stringData:
+  pre-job-hook: |-
+    echo "hello from custom pre-job hook script"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-agent-type-2-pod-spec
+  namespace: semaphore
+data:
+  pod: |-
+    volumes:
+    - name: pre-job-hook
+      secret:
+        secretName: custom-pre-job-hook-for-my-agent-type-1
+        defaultMode: 0644
+        items:
+        - key: pre-job-hook
+          path: pre-job-hook
+  mainContainer: |-
+    env:
+    - name: FOO_1
+      value: DIFFERENT_VALUE_1
+    - name: FOO_2
+      value: DIFFERENT_VALUE_2
+    resources:
+      limits:
+        cpu: "0.5"
+        memory: 500Mi
+      requests:
+        cpu: "0.25"
+        memory: 250Mi
+    volumeMounts:
+      - name: pre-job-hook
+        mountPath: /opt/semaphore/hooks
+        readOnly: true
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-semaphore-agent-type-2
+  namespace: semaphore
+  labels:
+    semaphoreci.com/resource-type: agent-type-configuration
+stringData:
+  agentTypeName: s1-my-agent-type-2
+  registrationToken: <registration-token>
+  agentStartupParameters: |-
+    "--kubernetes-pod-spec my-agent-type-2-pod-spec --pre-job-hook-path /opt/semaphore/hooks/pre-job-hook"
+```
+
+## Logging
+
+Since agent pods are deleted by the controller when the job finishes, it is recommended to configure your Kubernetes cluster to stream the agent pod logs to an external place, to help with troubleshooting, if needed. [This guide](https://kubernetes.io/docs/concepts/cluster-administration/logging/#cluster-level-logging-architectures) describes the usual strategies to accomplish that.
+
+## Configuration
+
+All the available configuration values can be seen with `helm show values renderedtext/controller`.

--- a/charts/controller/README.md
+++ b/charts/controller/README.md
@@ -10,6 +10,7 @@ Run Semaphore jobs for one or multiple [Semaphore agent type](https://github.com
   - [Do not specify a default pod spec](#do-not-specify-a-default-pod-spec)
   - [Overriding the default pod spec values](#overriding-the-default-pod-spec-values)
   - [Overriding the default pod spec for a single agent type](#overriding-the-default-pod-spec-for-a-single-agent-type)
+- [Job retention policies](#job-retention-policies)
 - [Logging](#logging)
 - [Configuration](#configuration)
 
@@ -191,6 +192,20 @@ stringData:
   registrationToken: <registration-token>
   agentStartupParameters: |-
     "--kubernetes-pod-spec my-agent-type-2-pod-spec --pre-job-hook-path /opt/semaphore/hooks/pre-job-hook"
+```
+
+## Job retention policies
+
+By default, all successful Kubernetes jobs are deleted after they are finished, and all failed jobs are kept for 1 day to help with troubleshooting purposes. However, those values can be configured. For example, you can keep all failed jobs for 7 days, and all successful jobs for 15 minutes, with:
+
+```bash
+helm upgrade --install semaphore-controller charts/controller \
+  --namespace semaphore \
+  --create-namespace \
+  --set endpoint=<your-organization>.semaphoreci.com \
+  --set apiToken=<your-api-token> \
+  --set keepFailedJobsFor=7d \
+  --set keepSuccessfulJobsFor=15m
 ```
 
 ## Logging

--- a/charts/controller/README.md
+++ b/charts/controller/README.md
@@ -11,12 +11,15 @@ Run Semaphore jobs for one or multiple [Semaphore agent type](https://github.com
   - [Overriding the default pod spec values](#overriding-the-default-pod-spec-values)
   - [Overriding the default pod spec for a single agent type](#overriding-the-default-pod-spec-for-a-single-agent-type)
 - [Job retention policies](#job-retention-policies)
+- [Job start timeouts](#job-start-timeouts)
 - [Logging](#logging)
 - [Configuration](#configuration)
 
 ## Installation
 
-Using the Semaphore API token, install the chart:
+This chart installs the [agent-k8s-controller](https://github.com/renderedtext/agent-k8s-controller) into your Kubernetes cluster.
+
+You can install it with your Semaphore API token and your Semaphore organization endpoint:
 
 ```bash
 helm upgrade --install semaphore-controller charts/controller \
@@ -206,6 +209,21 @@ helm upgrade --install semaphore-controller charts/controller \
   --set apiToken=<your-api-token> \
   --set keepFailedJobsFor=7d \
   --set keepSuccessfulJobsFor=15m
+```
+
+## Job start timeouts
+
+By default, if the Kubernetes job created by the controller does not start in 5 minutes, it will cancel it, deleting it. You can override that behavior with the `jobStartTimeout` parameter.
+
+For example, if you want to extend the timeout to 30 minutes instead, you can do it with:
+
+```bash
+helm upgrade --install semaphore-controller charts/controller \
+  --namespace semaphore \
+  --create-namespace \
+  --set endpoint=<your-organization>.semaphoreci.com \
+  --set apiToken=<your-api-token> \
+  --set jobStartTimeout=30m
 ```
 
 ## Logging

--- a/charts/controller/pre-job-hook.sh
+++ b/charts/controller/pre-job-hook.sh
@@ -1,0 +1,35 @@
+# Install the Semaphore toolbox in the job
+rm -rf ~/.toolbox
+
+downloadPath="https://github.com/semaphoreci/toolbox/releases/download/v1.19.40/self-hosted-linux.tar"
+echo "Downloading Semaphore toolbox from $downloadPath..."
+curl -sL --retry 5 --connect-timeout 3 $downloadPath -o /tmp/toolbox.tar
+tar -xvf /tmp/toolbox.tar
+mv toolbox ~/.toolbox
+if [ ! -d ~/.toolbox ]; then
+  echo "Failed to download toolbox."
+  return 1
+fi
+
+echo "Installing..."
+bash ~/.toolbox/install-toolbox
+if [ "$?" -ne "0" ]; then
+  echo "Failed to install toolbox."
+  rm -rf $SEMAPHORE_GIT_DIR
+fi
+
+source ~/.toolbox/toolbox
+if [ "$?" -ne "0" ]; then
+  echo "Failed to source toolbox."
+  rm -rf $SEMAPHORE_GIT_DIR
+fi
+
+echo "Semaphore toolbox successfully installed."
+
+# Create SSH configuration.
+# This is required in order to avoid having to manually accept the GitHub SSH keys fingerprints on checkout.
+# Ideally, we should populate ~/.ssh/known_hosts with the GitHub keys from api.github.com/meta.
+mkdir -p ~/.ssh
+echo 'Host github.com' | tee -a ~/.ssh/config
+echo '  StrictHostKeyChecking no' | tee -a ~/.ssh/config
+echo '  UserKnownHostsFile=/dev/null' | tee -a ~/.ssh/config

--- a/charts/controller/pre-job-hook.sh
+++ b/charts/controller/pre-job-hook.sh
@@ -1,7 +1,11 @@
 # Install the Semaphore toolbox in the job
 rm -rf ~/.toolbox
 
-downloadPath="https://github.com/semaphoreci/toolbox/releases/download/v1.19.40/self-hosted-linux.tar"
+downloadPath="https://github.com/semaphoreci/toolbox/releases/latest/download/self-hosted-linux.tar"
+if [ ! -z "${SEMAPHORE_TOOLBOX_VERSION}" ]; then
+  downloadPath="https://github.com/semaphoreci/toolbox/releases/download/$SEMAPHORE_TOOLBOX_VERSION/self-hosted-linux.tar"
+fi
+
 echo "Downloading Semaphore toolbox from $downloadPath..."
 curl -sL --retry 5 --connect-timeout 3 $downloadPath -o /tmp/toolbox.tar
 tar -xvf /tmp/toolbox.tar

--- a/charts/controller/templates/_helpers.tpl
+++ b/charts/controller/templates/_helpers.tpl
@@ -49,3 +49,68 @@ Selector labels
 app.kubernetes.io/name: {{ include "controller.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Expand the name of the default pod spec config map.
+*/}}
+{{- define "controller.agent.defaultPodSpec.name" -}}
+{{ include "controller.fullname" . }}-pod-spec
+{{- end }}
+
+{{/*
+Define the main container configuration for the default pod spec.
+*/}}
+{{- define "controller.agent.defaultPodSpec.mainContainer" -}}
+{{- if .Values.agent.defaultPodSpec.enabled }}
+{{- $mainContainerSpec := deepCopy .Values.agent.defaultPodSpec.mainContainer }}
+{{- if .Values.agent.defaultPodSpec.preJobHook.enabled }}
+{{- $preJobHookMount := dict "name" "agent-config-volume" "mountPath" .Values.agent.defaultPodSpec.preJobHook.path "readOnly" true }}
+{{- $currentVolumeMounts := $mainContainerSpec.volumeMounts | default list }}
+{{- $newVolumeMounts := append $currentVolumeMounts $preJobHookMount }}
+{{- $_ := set $mainContainerSpec "volumeMounts" $newVolumeMounts }}
+{{- end }}
+{{- toYaml $mainContainerSpec }}
+{{- else }}
+{{- toYaml dict }}
+{{- end }}
+{{- end }}
+
+{{/*
+Define the pod configuration for the default pod spec.
+*/}}
+{{- define "controller.agent.defaultPodSpec.pod" -}}
+{{- if .Values.agent.defaultPodSpec.enabled }}
+{{- $podSpec := deepCopy .Values.agent.defaultPodSpec.pod }}
+{{- if .Values.agent.defaultPodSpec.preJobHook.enabled }}
+{{- $secretItem := dict "key" "pre-job-hook" "path" "pre-job-hook" }}
+{{- $secretDict := dict "secretName" (include "controller.fullname" .) "defaultMode" 0644 "items" (list $secretItem) }}
+{{- $preJobHookVolume := dict "name" "agent-config-volume" "secret" $secretDict }}
+{{- $currentVolumes := $podSpec.volumes | default list }}
+{{- $newVolumes := append $currentVolumes $preJobHookVolume }}
+{{- $_ := set $podSpec "volumes" $newVolumes }}
+{{- end }}
+{{- toYaml $podSpec }}
+{{- else }}
+{{- toYaml dict }}
+{{- end }}
+{{- end }}
+
+{{/*
+Expand the name of the default pod spec config map.
+*/}}
+{{- define "controller.agent.startupParameters" -}}
+{{- $startupParameters := list }}
+{{- if .Values.agent.defaultPodSpec.enabled }}
+{{- $startupParameters = append $startupParameters "--kubernetes-pod-spec" }}
+{{- $startupParameters = append $startupParameters (include "controller.agent.defaultPodSpec.name" .) }}
+{{- end }}
+{{- if .Values.agent.defaultPodSpec.preJobHook.enabled }}
+{{- $startupParameters = append $startupParameters "--pre-job-hook-path" }}
+{{- $startupParameters = append $startupParameters (printf "%s/pre-job-hook" .Values.agent.defaultPodSpec.preJobHook.path) }}
+{{- $startupParameters = append $startupParameters "--source-pre-job-hook" }}
+{{- end }}
+{{- if .Values.agent.defaultPodSpec.preJobHook.failOnError }}
+{{- $startupParameters = append $startupParameters "--fail-on-pre-job-hook-error" }}
+{{- end }}
+{{- join " " $startupParameters }}
+{{- end }}

--- a/charts/controller/templates/_helpers.tpl
+++ b/charts/controller/templates/_helpers.tpl
@@ -112,5 +112,13 @@ Expand the name of the default pod spec config map.
 {{- if .Values.agent.defaultPodSpec.preJobHook.failOnError }}
 {{- $startupParameters = append $startupParameters "--fail-on-pre-job-hook-error" }}
 {{- end }}
+{{- if .Values.agent.podStartTimeout }}
+{{- $startupParameters = append $startupParameters "--kubernetes-pod-start-timeout" }}
+{{- $startupParameters = append $startupParameters .Values.agent.podStartTimeout }}
+{{- end }}
+{{- if .Values.agent.allowedImages }}
+{{- $startupParameters = append $startupParameters "--kubernetes-allowed-images" }}
+{{- $startupParameters = append $startupParameters .Values.agent.allowedImages }}
+{{- end }}
 {{- join " " $startupParameters }}
 {{- end }}

--- a/charts/controller/templates/_helpers.tpl
+++ b/charts/controller/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "controller.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "controller.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "controller.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "controller.labels" -}}
+helm.sh/chart: {{ include "controller.chart" . }}
+{{ include "controller.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "controller.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "controller.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/controller/templates/config-map.yaml
+++ b/charts/controller/templates/config-map.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.agent.defaultPodSpec.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "controller.agent.defaultPodSpec.name" . }}
+  labels:
+    {{- include "controller.labels" . | nindent 4 }}
+data:
+  mainContainer: |
+{{ include "controller.agent.defaultPodSpec.mainContainer" . | indent 4 }}
+  pod: |
+{{ include "controller.agent.defaultPodSpec.pod" . | indent 4 }}
+{{- end }}

--- a/charts/controller/templates/deployment.yaml
+++ b/charts/controller/templates/deployment.yaml
@@ -40,6 +40,8 @@ spec:
                   key: endpoint
             - name: SEMAPHORE_AGENT_IMAGE
               value: "{{ .Values.agent.image }}:{{ .Values.agent.version }}"
+            - name: SEMAPHORE_AGENT_STARTUP_PARAMETERS
+              value: "{{ include "controller.agent.startupParameters" . }}"
             - name: KUBERNETES_SERVICE_ACCOUNT
               value: "{{ include "controller.fullname" . }}-agent"
             - name: MAX_PARALLEL_JOBS

--- a/charts/controller/templates/deployment.yaml
+++ b/charts/controller/templates/deployment.yaml
@@ -23,6 +23,8 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image }}:{{ .Values.imageTag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.imagePullPolicy }}
+          args:
+            - -v={{ .Values.logs.verbosity }}
           env:
             - name: KUBERNETES_NAMESPACE
               valueFrom:

--- a/charts/controller/templates/deployment.yaml
+++ b/charts/controller/templates/deployment.yaml
@@ -10,6 +10,9 @@ spec:
     matchLabels:
       {{- include "controller.selectorLabels" . | nindent 6 }}
   template:
+    metadata:
+      labels:
+        {{- include "controller.selectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "controller.fullname" . }}
       securityContext:

--- a/charts/controller/templates/deployment.yaml
+++ b/charts/controller/templates/deployment.yaml
@@ -48,5 +48,9 @@ spec:
               value: "{{ include "controller.fullname" . }}-agent"
             - name: MAX_PARALLEL_JOBS
               value: "{{ .Values.parallelism }}"
+            - name: KEEP_FAILED_JOBS_FOR
+              value: "{{ .Values.keepFailedJobsFor }}"
+            - name: KEEP_SUCCESSFUL_JOBS_FOR
+              value: "{{ .Values.keepSuccessfulJobsFor }}"
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/controller/templates/deployment.yaml
+++ b/charts/controller/templates/deployment.yaml
@@ -52,5 +52,7 @@ spec:
               value: "{{ .Values.keepFailedJobsFor }}"
             - name: KEEP_SUCCESSFUL_JOBS_FOR
               value: "{{ .Values.keepSuccessfulJobsFor }}"
+            - name: JOB_START_TIMEOUT
+              value: "{{ .Values.jobStartTimeout }}"
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/controller/templates/deployment.yaml
+++ b/charts/controller/templates/deployment.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "controller.fullname" . }}
+  labels:
+    {{- include "controller.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "controller.selectorLabels" . | nindent 6 }}
+  template:
+    spec:
+      serviceAccountName: {{ include "controller.fullname" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image }}:{{ .Values.imageTag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: SEMAPHORE_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "controller.fullname" . }}
+                  key: apiToken
+            - name: SEMAPHORE_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "controller.fullname" . }}
+                  key: endpoint
+            - name: SEMAPHORE_AGENT_IMAGE
+              value: "{{ .Values.agent.image }}:{{ .Values.agent.version }}"
+            - name: KUBERNETES_SERVICE_ACCOUNT
+              value: "{{ include "controller.fullname" . }}-agent"
+            - name: MAX_PARALLEL_JOBS
+              value: "{{ .Values.parallelism }}"
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/controller/templates/rbac.yaml
+++ b/charts/controller/templates/rbac.yaml
@@ -17,7 +17,7 @@ rules:
     verbs: ["get", "create", "delete"]
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "list"]
+    verbs: ["get", "watch", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/controller/templates/rbac.yaml
+++ b/charts/controller/templates/rbac.yaml
@@ -1,0 +1,75 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "controller.fullname" . }}
+  labels:
+    {{- include "controller.labels" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "controller.fullname" . }}
+  labels:
+    {{- include "controller.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "controller.fullname" . }}
+  labels:
+    {{- include "controller.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "controller.fullname" . }}
+roleRef:
+  kind: Role
+  apiGroup: rbac.authorization.k8s.io
+  name: {{ include "controller.fullname" . }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "controller.fullname" . }}-agent
+  labels:
+    {{- include "controller.labels" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "controller.fullname" . }}-agent
+  labels:
+    {{- include "controller.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "create", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "controller.fullname" . }}-agent
+  labels:
+    {{- include "controller.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "controller.fullname" . }}-agent
+roleRef:
+  kind: Role
+  apiGroup: rbac.authorization.k8s.io
+  name: {{ include "controller.fullname" . }}-agent

--- a/charts/controller/templates/rbac.yaml
+++ b/charts/controller/templates/rbac.yaml
@@ -16,6 +16,9 @@ rules:
     resources: ["jobs"]
     verbs: ["get", "create", "delete", "list", "watch"]
   - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["list"]
+  - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "watch", "list"]
 ---

--- a/charts/controller/templates/rbac.yaml
+++ b/charts/controller/templates/rbac.yaml
@@ -14,7 +14,7 @@ metadata:
 rules:
   - apiGroups: ["batch"]
     resources: ["jobs"]
-    verbs: ["get", "create", "delete"]
+    verbs: ["get", "create", "delete", "list", "watch"]
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "watch", "list"]

--- a/charts/controller/templates/secret.yaml
+++ b/charts/controller/templates/secret.yaml
@@ -10,3 +10,10 @@ metadata:
 stringData:
   endpoint: {{ $endpoint }}
   apiToken: {{ $apiToken }}
+{{- if and .Values.agent.defaultPodSpec.preJobHook.enabled .Values.agent.defaultPodSpec.preJobHook.customScript }}
+  pre-job-hook: |
+{{ .Values.agent.defaultPodSpec.preJobHook.customScript | b64dec | indent 4 }}
+  {{- else }}
+  pre-job-hook: |
+{{ .Files.Get "pre-job-hook.sh" | indent 4 }}
+  {{- end }}

--- a/charts/controller/templates/secret.yaml
+++ b/charts/controller/templates/secret.yaml
@@ -13,7 +13,7 @@ stringData:
 {{- if and .Values.agent.defaultPodSpec.preJobHook.enabled .Values.agent.defaultPodSpec.preJobHook.customScript }}
   pre-job-hook: |
 {{ .Values.agent.defaultPodSpec.preJobHook.customScript | b64dec | indent 4 }}
-  {{- else }}
+  {{- else if .Values.agent.defaultPodSpec.preJobHook.enabled }}
   pre-job-hook: |
 {{ .Files.Get "pre-job-hook.sh" | indent 4 }}
   {{- end }}

--- a/charts/controller/templates/secret.yaml
+++ b/charts/controller/templates/secret.yaml
@@ -1,0 +1,12 @@
+{{- $endpoint := .Values.endpoint | required ".Values.endpoint is required." -}}
+{{- $apiToken := .Values.apiToken | required ".Values.apiToken is required." -}}
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "controller.fullname" . }}
+  labels:
+    {{- include "controller.labels" . | nindent 4 }}
+stringData:
+  endpoint: {{ $endpoint }}
+  apiToken: {{ $apiToken }}

--- a/charts/controller/values.yaml
+++ b/charts/controller/values.yaml
@@ -30,6 +30,12 @@ agent:
       failOnError: true
       customScript: ""
 
+  # See: https://github.com/semaphoreci/agent/blob/master/docs/kubernetes-executor.md#--kubernetes-pod-start-timeout
+  podStartTimeout: 300
+
+  # See: https://github.com/semaphoreci/agent/blob/master/docs/kubernetes-executor.md#restricting-images-used-in-jobs
+  allowedImages: ""
+
 # How many jobs the controller will keep running in parallel
 parallelism: 10
 

--- a/charts/controller/values.yaml
+++ b/charts/controller/values.yaml
@@ -22,8 +22,11 @@ agent:
   defaultPodSpec:
     enabled: true
     pod: {}
-    mainContainer: {}
     sidecarContainers: {}
+    mainContainer:
+      env:
+      - name: SEMAPHORE_TOOLBOX_VERSION
+        value: v1.21.7
     preJobHook:
       enabled: true
       path: "/opt/semaphore/hooks"

--- a/charts/controller/values.yaml
+++ b/charts/controller/values.yaml
@@ -18,7 +18,6 @@ agent:
   # TODO
   allowedImagesForJobs: []
 
-  # TODO
   # By default, the controller creates a pod spec which will be used
   # if no pod spec are specified in the agent types secret.
   # The default pod spec adds a pre-job hook which installs the Semaphore toolbox.
@@ -28,6 +27,11 @@ agent:
     pod: {}
     mainContainer: {}
     sidecarContainers: {}
+    preJobHook:
+      enabled: true
+      path: "/opt/semaphore/hooks"
+      failOnError: true
+      customScript: ""
 
 # How many jobs the controller will keep running in parallel
 parallelism: 10

--- a/charts/controller/values.yaml
+++ b/charts/controller/values.yaml
@@ -15,9 +15,6 @@ agent:
   image: semaphoreci/agent
   version: v2.2.14
 
-  # TODO
-  allowedImagesForJobs: []
-
   # By default, the controller creates a pod spec which will be used
   # if no pod spec are specified in the agent types secret.
   # The default pod spec adds a pre-job hook which installs the Semaphore toolbox.

--- a/charts/controller/values.yaml
+++ b/charts/controller/values.yaml
@@ -1,0 +1,39 @@
+# Default values for controller.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# The Semaphore API token and endpoint used by the controller to look into the job queue.
+# These are the only required values for this chart.
+apiToken: ""
+endpoint: ""
+
+image: semaphoreci/controller
+imageTag: ""
+imagePullPolicy: IfNotPresent
+
+agent:
+  image: semaphoreci/agent
+  version: v2.2.14
+
+  # TODO
+  allowedImagesForJobs: []
+
+  # TODO
+  # By default, the controller creates a pod spec which will be used
+  # if no pod spec are specified in the agent types secret.
+  # The default pod spec adds a pre-job hook which installs the Semaphore toolbox.
+  # See: https://github.com/semaphoreci/agent/blob/master/docs/kubernetes-executor.md#--kubernetes-pod-spec
+  defaultPodSpec:
+    enabled: true
+    pod: {}
+    mainContainer: {}
+    sidecarContainers: {}
+
+# How many jobs the controller will keep running in parallel
+parallelism: 10
+
+nameOverride: ""
+fullnameOverride: ""
+resources: {}
+securityContext: {}
+podSecurityContext: {}

--- a/charts/controller/values.yaml
+++ b/charts/controller/values.yaml
@@ -44,6 +44,9 @@ parallelism: 10
 keepFailedJobsFor: 1d
 keepSuccessfulJobsFor: 0
 
+# How long to wait for the Kubernetes job to start running before cancelling it.
+jobStartTimeout: 5m
+
 # Configures log verbosity.
 # See: https://github.com/kubernetes/klog
 logs:

--- a/charts/controller/values.yaml
+++ b/charts/controller/values.yaml
@@ -39,6 +39,11 @@ agent:
 # How many jobs the controller will keep running in parallel
 parallelism: 10
 
+# By default, we keep failed Kubernetes jobs for 1 day, for troubleshooting purposes.
+# Successful jobs are deleted immediately after they finish.
+keepFailedJobsFor: 1d
+keepSuccessfulJobsFor: 0
+
 # Configures log verbosity.
 # See: https://github.com/kubernetes/klog
 logs:

--- a/charts/controller/values.yaml
+++ b/charts/controller/values.yaml
@@ -39,6 +39,11 @@ agent:
 # How many jobs the controller will keep running in parallel
 parallelism: 10
 
+# Configures log verbosity.
+# See: https://github.com/kubernetes/klog
+logs:
+  verbosity: "4"
+
 nameOverride: ""
 fullnameOverride: ""
 resources: {}

--- a/charts/external-metrics-server/README.md
+++ b/charts/external-metrics-server/README.md
@@ -1,3 +1,6 @@
+> [!WARNING]
+> This chart is deprecated. It does not work well with versions of Kubernetes >= 1.26. Please, use the [Semaphore custom controller chart](../controller) to run Semaphore jobs in your Kubernetes cluster.
+
 Installs an [external metrics server](https://github.com/renderedtext/k8s-metrics-apiserver) that exposes self-hosted agent types metrics through the Kubernetes external metrics API.
 
 ### Installation


### PR DESCRIPTION
### Motivation

The current charts available do not work well with Kubernetes 1.26+. See https://github.com/renderedtext/helm-charts/pull/22 for more details on why.

### Solution

Since we couldn't get around the Kubernetes' native resources shortcomings, we created a [custom controller](https://github.com/renderedtext/agent-k8s-controller). This chart installs it, with a few niceties - for example, a default pre-job hook that installs the Semaphore toolbox.

All the details about how the controller works should be in its README.

### Other changes

I added deprecation warnings to the agent and external-metrics-server charts, since those should not be used anymore.