### PR TITLE
fix(controller): update default agent version

### DIFF
--- a/charts/controller/Chart.yaml
+++ b/charts/controller/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/controller/Chart.yaml
+++ b/charts/controller/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.1.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.1.0"
+appVersion: "v0.1.1"

--- a/charts/controller/values.yaml
+++ b/charts/controller/values.yaml
@@ -13,7 +13,7 @@ imagePullPolicy: IfNotPresent
 
 agent:
   image: semaphoreci/agent
-  version: v2.2.14
+  version: v2.2.15
 
   # By default, the controller creates a pod spec which will be used
   # if no pod spec are specified in the agent types secret.


### PR DESCRIPTION
### Issue

Currently, the chart does not work unless you override the default agent version being used (v2.2.14).

### Solution

We should use [v2.2.15](https://github.com/semaphoreci/agent/releases/tag/v2.2.15) instead, which has a few additional changes required by the controller. We also update the `appVersion` to v0.1.1, since a [new controller has been released](https://github.com/renderedtext/agent-k8s-controller/releases/tag/v0.1.1) with a bug fix.