### PR TITLE
fix(controller): update default controller version to v0.1.2

### DIFF
--- a/charts/controller/Chart.yaml
+++ b/charts/controller/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.1.1"
+appVersion: "v0.1.2"


### PR DESCRIPTION
A new controller [v0.1.2](https://github.com/renderedtext/agent-k8s-controller/releases/tag/v0.1.2) was released with a bug fix. Here, we update the default version being used by the chart, and its version.