### PR TITLE
Fix docs on pod spec override for single agent type

### DIFF
--- a/charts/controller/README.md
+++ b/charts/controller/README.md
@@ -194,7 +194,7 @@ stringData:
   agentTypeName: s1-my-agent-type-2
   registrationToken: <registration-token>
   agentStartupParameters: |-
-    --kubernetes-pod-spec my-agent-type-2-pod-spec --pre-job-hook-path /opt/semaphore/hooks/pre-job-hook
+    --kubernetes-pod-spec my-agent-type-2-pod-spec --pre-job-hook-path /opt/semaphore/hooks/pre-job-hook --source-pre-job-hook --fail-on-pre-job-hook-error
 ```
 
 ## Job retention policies

--- a/charts/controller/README.md
+++ b/charts/controller/README.md
@@ -194,7 +194,7 @@ stringData:
   agentTypeName: s1-my-agent-type-2
   registrationToken: <registration-token>
   agentStartupParameters: |-
-    "--kubernetes-pod-spec my-agent-type-2-pod-spec --pre-job-hook-path /opt/semaphore/hooks/pre-job-hook"
+    --kubernetes-pod-spec my-agent-type-2-pod-spec --pre-job-hook-path /opt/semaphore/hooks/pre-job-hook
 ```
 
 ## Job retention policies


### PR DESCRIPTION
This was a mistake in our documentation. If we use double quotes there, the arguments for the container will be:

```
Args:
      --endpoint
      semaphore.semaphoreci.com
      --job-id
      5eae54ca-1013-4fb9-a042-0677c19090cb
      --kubernetes-labels
      semaphoreci.com/agent-type=s1-test
      --kubernetes-executor
      --disconnect-after-job
      "--kubernetes-pod-spec
      s1-test
      --pre-job-hook-path
      /opt/semaphore/hooks/pre-job-hook"
```

And we want them to be:

```
Args:
      --endpoint
      semaphore.semaphoreci.com
      --job-id
      5eae54ca-1013-4fb9-a042-0677c19090cb
      --kubernetes-labels
      semaphoreci.com/agent-type=s1-test
      --kubernetes-executor
      --disconnect-after-job
      --kubernetes-pod-spec
      s1-test-pod-spec
      --pre-job-hook-path
      /opt/semaphore/hooks/pre-job-hook
```

Also, added the `--source-pre-job-hook --fail-on-pre-job-hook-error` parameters in the documentation because the pre-job hook needs to be always sourced.