### PR TITLE
build(controller): update to controller v0.2.0

### DIFF
--- a/charts/controller/Chart.yaml
+++ b/charts/controller/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.1.2"
+appVersion: "v0.2.0"

--- a/charts/controller/README.md
+++ b/charts/controller/README.md
@@ -19,14 +19,13 @@ Run Semaphore jobs for one or multiple [Semaphore agent type](https://github.com
 
 This chart installs the [agent-k8s-controller](https://github.com/renderedtext/agent-k8s-controller) into your Kubernetes cluster.
 
-You can install it with your Semaphore API token and your Semaphore organization endpoint:
+You can install it with your Semaphore organization endpoint:
 
 ```bash
 helm upgrade --install semaphore-controller charts/controller \
   --namespace semaphore \
   --create-namespace \
-  --set endpoint=<your-organization>.semaphoreci.com \
-  --set apiToken=<your-api-token>
+  --set endpoint=<your-organization>.semaphoreci.com
 ```
 
 ## Start jobs for an agent type
@@ -76,7 +75,6 @@ helm upgrade --install semaphore-controller charts/controller \
   --namespace semaphore \
   --create-namespace \
   --set endpoint=<your-organization>.semaphoreci.com \
-  --set apiToken=<your-api-token> \
   --set agent.defaultPodSpec.preJobHook.enabled=false
 ```
 
@@ -89,7 +87,6 @@ helm upgrade --install semaphore-controller charts/controller \
   --namespace semaphore \
   --create-namespace \
   --set endpoint=<your-organization>.semaphoreci.com \
-  --set apiToken=<your-api-token> \
   --set agent.defaultPodSpec.preJobHook.customScript=$(cat my-custom-script.sh | base64)
 ```
 
@@ -102,7 +99,6 @@ helm upgrade --install semaphore-controller charts/controller \
   --namespace semaphore \
   --create-namespace \
   --set endpoint=<your-organization>.semaphoreci.com \
-  --set apiToken=<your-api-token> \
   --set agent.defaultPodSpec.enabled=false
 ```
 
@@ -114,7 +110,6 @@ For example, if you have a `custom-values.yml` file like this:
 
 ```yaml
 endpoint: <your-organization>.semaphoreci.com
-apiToken: <your-api-token>
 agent:
   defaultPodSpec:
     mainContainer:
@@ -206,7 +201,6 @@ helm upgrade --install semaphore-controller charts/controller \
   --namespace semaphore \
   --create-namespace \
   --set endpoint=<your-organization>.semaphoreci.com \
-  --set apiToken=<your-api-token> \
   --set keepFailedJobsFor=7d \
   --set keepSuccessfulJobsFor=15m
 ```
@@ -222,7 +216,6 @@ helm upgrade --install semaphore-controller charts/controller \
   --namespace semaphore \
   --create-namespace \
   --set endpoint=<your-organization>.semaphoreci.com \
-  --set apiToken=<your-api-token> \
   --set jobStartTimeout=30m
 ```
 

--- a/charts/controller/templates/deployment.yaml
+++ b/charts/controller/templates/deployment.yaml
@@ -30,11 +30,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            - name: SEMAPHORE_API_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "controller.fullname" . }}
-                  key: apiToken
             - name: SEMAPHORE_ENDPOINT
               valueFrom:
                 secretKeyRef:

--- a/charts/controller/templates/secret.yaml
+++ b/charts/controller/templates/secret.yaml
@@ -1,5 +1,4 @@
 {{- $endpoint := .Values.endpoint | required ".Values.endpoint is required." -}}
-{{- $apiToken := .Values.apiToken | required ".Values.apiToken is required." -}}
 
 apiVersion: v1
 kind: Secret
@@ -9,7 +8,6 @@ metadata:
     {{- include "controller.labels" . | nindent 4 }}
 stringData:
   endpoint: {{ $endpoint }}
-  apiToken: {{ $apiToken }}
 {{- if and .Values.agent.defaultPodSpec.preJobHook.enabled .Values.agent.defaultPodSpec.preJobHook.customScript }}
   pre-job-hook: |
 {{ .Values.agent.defaultPodSpec.preJobHook.customScript | b64dec | indent 4 }}

--- a/charts/controller/values.yaml
+++ b/charts/controller/values.yaml
@@ -2,9 +2,8 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# The Semaphore API token and endpoint used by the controller to look into the job queue.
-# These are the only required values for this chart.
-apiToken: ""
+# The Semaphore endpoint used by the controller to look into the job queue.
+# This is the only required value for this chart.
 endpoint: ""
 
 image: semaphoreci/controller

--- a/charts/controller/values.yaml
+++ b/charts/controller/values.yaml
@@ -12,7 +12,7 @@ imagePullPolicy: IfNotPresent
 
 agent:
   image: semaphoreci/agent
-  version: v2.2.15
+  version: v2.2.28
 
   # By default, the controller creates a pod spec which will be used
   # if no pod spec are specified in the agent types secret.
@@ -25,7 +25,7 @@ agent:
     mainContainer:
       env:
       - name: SEMAPHORE_TOOLBOX_VERSION
-        value: v1.21.7
+        value: v1.22.2
     preJobHook:
       enabled: true
       path: "/opt/semaphore/hooks"


### PR DESCRIPTION
https://github.com/renderedtext/project-tasks/issues/1542

A new [v0.2.0 controller version](https://github.com/renderedtext/agent-k8s-controller/releases/tag/v0.2.0) was released. In that, the controller is able to work without a Semaphore API token, using a new endpoint and the agent type registration tokens for looking at the job queue. This will make the chart easier to configure since it will have one less required argument.

This pull request also updates a few more things:
- Semaphore agent version: v2.2.15 -> v2.2.28
- Semaphore toolbox: v1.21.7 -> v1.22.2