### PR TITLE
feat(controller): allow endpoint to be specified through secret

### DIFF
--- a/charts/controller/Chart.yaml
+++ b/charts/controller/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/controller/templates/_helpers.tpl
+++ b/charts/controller/templates/_helpers.tpl
@@ -122,3 +122,27 @@ Expand the name of the default pod spec config map.
 {{- end }}
 {{- join " " $startupParameters }}
 {{- end }}
+
+{{/*
+The name of the secret containing the endpoint URL.
+By default, this is the secret created by the chart.
+*/}}
+{{- define "controller.endpoint.secretName" -}}
+{{- if ne .Values.endpointSecret.name "" }}
+{{- .Values.endpointSecret.name }}
+{{- else }}
+{{- include "controller.fullname" . }}
+{{- end }}
+{{- end }}
+
+{{/*
+The key of the secret containing the endpoint URL.
+By default, this is "endpoint".
+*/}}
+{{- define "controller.endpoint.secretKey" -}}
+{{- if ne .Values.endpointSecret.name "" }}
+{{- .Values.endpointSecret.key }}
+{{- else }}
+{{- "endpoint" }}
+{{- end }}
+{{- end }}

--- a/charts/controller/templates/deployment.yaml
+++ b/charts/controller/templates/deployment.yaml
@@ -33,8 +33,8 @@ spec:
             - name: SEMAPHORE_ENDPOINT
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "controller.fullname" . }}
-                  key: endpoint
+                  name: {{ include "controller.endpoint.secretName" . }}
+                  key: {{ include "controller.endpoint.secretKey" . }}
             - name: SEMAPHORE_AGENT_IMAGE
               value: "{{ .Values.agent.image }}:{{ .Values.agent.version }}"
             - name: SEMAPHORE_AGENT_STARTUP_PARAMETERS

--- a/charts/controller/templates/secret.yaml
+++ b/charts/controller/templates/secret.yaml
@@ -1,4 +1,6 @@
-{{- $endpoint := .Values.endpoint | required ".Values.endpoint is required." -}}
+{{- if and (eq .Values.endpointSecret.name "") (eq .Values.endpoint "") }}
+  {{- fail "Either .Values.endpoint or .Values.endpointSecret.name must be set" }}
+{{- end }}
 
 apiVersion: v1
 kind: Secret
@@ -7,7 +9,9 @@ metadata:
   labels:
     {{- include "controller.labels" . | nindent 4 }}
 stringData:
-  endpoint: {{ $endpoint }}
+{{- if ne .Values.endpoint "" }}
+  endpoint: {{ .Values.endpoint }}
+{{- end }}
 {{- if and .Values.agent.defaultPodSpec.preJobHook.enabled .Values.agent.defaultPodSpec.preJobHook.customScript }}
   pre-job-hook: |
 {{ .Values.agent.defaultPodSpec.preJobHook.customScript | b64dec | indent 4 }}

--- a/charts/controller/values.yaml
+++ b/charts/controller/values.yaml
@@ -4,7 +4,12 @@
 
 # The Semaphore endpoint used by the controller to look into the job queue.
 # This is the only required value for this chart.
+# It can be specified as a raw value with .Values.endpoint,
+# or as a secret with .Values.endpointSecret.name and .Values.endpointSecret.key
 endpoint: ""
+endpointSecret:
+  name: ""
+  key: "endpoint"
 
 image: semaphoreci/controller
 imageTag: ""


### PR DESCRIPTION
https://github.com/renderedtext/project-tasks/issues/1542

Sometimes, we need to specify the endpoint through an existing secret, instead of as a raw value that will be put into a secret. With this change, we can do that with:
```
helm upgrade --install <name> charts/controller --set endpointSecret.name=<secret-name>
```

You'd still need to specify either `.Values.endpoint` or `.Values.endpointSecret.name` for it to install though:

```
$ helm upgrade --install <name> charts/controller
Error: execution error at (controller/templates/secret.yaml:2:6): Either .Values.endpoint or .Values.endpointSecret.name must be set
```