### PR TITLE
fix(controller): configure agent log level

### DIFF
--- a/charts/controller/Chart.yaml
+++ b/charts/controller/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.2.0"
+appVersion: "v0.2.1"

--- a/charts/controller/templates/deployment.yaml
+++ b/charts/controller/templates/deployment.yaml
@@ -37,6 +37,8 @@ spec:
                   key: {{ include "controller.endpoint.secretKey" . }}
             - name: SEMAPHORE_AGENT_IMAGE
               value: "{{ .Values.agent.image }}:{{ .Values.agent.version }}"
+            - name: SEMAPHORE_AGENT_LOG_LEVEL
+              value: "{{ .Values.agent.logLevel }}"
             - name: SEMAPHORE_AGENT_STARTUP_PARAMETERS
               value: "{{ include "controller.agent.startupParameters" . }}"
             - name: KUBERNETES_SERVICE_ACCOUNT

--- a/charts/controller/values.yaml
+++ b/charts/controller/values.yaml
@@ -18,6 +18,7 @@ imagePullPolicy: IfNotPresent
 agent:
   image: semaphoreci/agent
   version: v2.2.28
+  logLevel: "info"
 
   # By default, the controller creates a pod spec which will be used
   # if no pod spec are specified in the agent types secret.


### PR DESCRIPTION
https://github.com/renderedtext/tasks/issues/7273

Uses https://github.com/renderedtext/agent-k8s-controller/releases/tag/v0.2.1, and exposes a new `.Values.agent.logLevel` for configuring the log level on the agent (default: `info`)